### PR TITLE
更新谷歌驱动版本，解决旧版本失效导致授权不能正常运行的问题

### DIFF
--- a/resource/colab/Colab之作业完整部署.md
+++ b/resource/colab/Colab之作业完整部署.md
@@ -35,8 +35,8 @@
 ```
 # 授权验证
 !apt-get install -y -qq software-properties-common python-software-properties module-init-tools
-!wget https://launchpad.net/~alessandro-strada/+archive/ubuntu/google-drive-ocamlfuse-beta/+build/15331130/+files/google-drive-ocamlfuse_0.7.0-0ubuntu1_amd64.deb
-!dpkg -i google-drive-ocamlfuse_0.7.0-0ubuntu1_amd64.deb
+!wget https://launchpad.net/~alessandro-strada/+archive/ubuntu/google-drive-ocamlfuse-beta/+build/15740102/+files/google-drive-ocamlfuse_0.7.1-0ubuntu3_amd64.deb
+!dpkg -i google-drive-ocamlfuse_0.7.1-0ubuntu3_amd64.deb
 !apt-get install -f
 !apt-get -y install -qq fuse
 from google.colab import auth

--- a/resource/colab/colab.md
+++ b/resource/colab/colab.md
@@ -55,8 +55,8 @@ Colaboratory 支持**在线安装包以及linux命令等操作**。
 
 ```python
 !apt-get install -y -qq software-properties-common python-software-properties module-init-tools
-!wget https://launchpad.net/~alessandro-strada/+archive/ubuntu/google-drive-ocamlfuse-beta/+build/15331130/+files/google-drive-ocamlfuse_0.7.0-0ubuntu1_amd64.deb
-!dpkg -i google-drive-ocamlfuse_0.7.0-0ubuntu1_amd64.deb
+!wget https://launchpad.net/~alessandro-strada/+archive/ubuntu/google-drive-ocamlfuse-beta/+build/15740102/+files/google-drive-ocamlfuse_0.7.1-0ubuntu3_amd64.deb
+!dpkg -i google-drive-ocamlfuse_0.7.1-0ubuntu3_amd64.deb
 !apt-get install -f
 !apt-get -y install -qq fuse
 from google.colab import auth


### PR DESCRIPTION
发现之前的授权代码运行报错

更新谷歌渠道版本，解决旧版本失效导致授权不能正常运行的问题